### PR TITLE
BUG OCPBUGS-7441: Match the O-RAN specification for the ocloudNotifications URI

### DIFF
--- a/listenerlib.go
+++ b/listenerlib.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	SubscriptionPath  = "/api/cloudNotifications/v1/subscriptions"
+	SubscriptionPath  = "/api/ocloudNotifications/v1/subscriptions"
 	LocalEventPath    = "/event"
 	LocalHealthPath   = "/health"
 	LocalAckEventPath = "/ack/event"


### PR DESCRIPTION
Adds the o in front of cloudNotifications URI
OCPBUGS-7441